### PR TITLE
Rename output binaries to slua instead of luau

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,26 +60,26 @@ jobs:
         sudo apt-get install g++-multilib
     - name: make tests
       run: |
-        LDFLAGS=-m${{matrix.addrsize}} CXXFLAGS="-m${{matrix.addrsize}} ${{matrix.cflags}}" CFLAGS="-m${{matrix.addrsize}} ${{matrix.cflags}}" make -j4 config=sanitize ${{ matrix.addrsize == '64' && 'native=1' || ''}} luau-tests
+        LDFLAGS=-m${{matrix.addrsize}} CXXFLAGS="-m${{matrix.addrsize}} ${{matrix.cflags}}" CFLAGS="-m${{matrix.addrsize}} ${{matrix.cflags}}" make -j4 config=sanitize ${{ matrix.addrsize == '64' && 'native=1' || ''}} slua-tests
     - name: run tests
       run: |
-        ./luau-tests
-        ./luau-tests --fflags=true
+        ./slua-tests
+        ./slua-tests --fflags=true
     - name: run extra conformance tests
       if: matrix.os.name != 'ubuntu-32bit'
       run: |
-        ./luau-tests -ts=Conformance -O2
-        ./luau-tests -ts=Conformance -O2 --fflags=true
-        ./luau-tests -ts=Conformance --codegen
-        ./luau-tests -ts=Conformance --codegen --fflags=true
-        ./luau-tests -ts=Conformance --codegen -O2
-        ./luau-tests -ts=Conformance --codegen -O2 --fflags=true
+        ./slua-tests -ts=Conformance -O2
+        ./slua-tests -ts=Conformance -O2 --fflags=true
+        ./slua-tests -ts=Conformance --codegen
+        ./slua-tests -ts=Conformance --codegen --fflags=true
+        ./slua-tests -ts=Conformance --codegen -O2
+        ./slua-tests -ts=Conformance --codegen -O2 --fflags=true
     - name: make cli
       run: |
-         LDFLAGS=-m${{matrix.addrsize}} CXXFLAGS="-m${{matrix.addrsize}} ${{matrix.cflags}} -DHARDSTACKTESTS=1" CFLAGS="-m${{matrix.addrsize}} ${{matrix.cflags}}" make -j4 config=sanitize ${{ matrix.addrsize == '64' && 'native=1' || ''}} werror=1 luau luau-analyze luau-compile # match config with tests to improve build time
-         ./luau tests/conformance/assert.luau
-         ./luau-analyze tests/conformance/assert.luau
-         ./luau-compile tests/conformance/assert.luau
+         LDFLAGS=-m${{matrix.addrsize}} CXXFLAGS="-m${{matrix.addrsize}} ${{matrix.cflags}} -DHARDSTACKTESTS=1" CFLAGS="-m${{matrix.addrsize}} ${{matrix.cflags}}" make -j4 config=sanitize ${{ matrix.addrsize == '64' && 'native=1' || ''}} werror=1 slua slua-analyze slua-compile # match config with tests to improve build time
+         ./slua tests/conformance/assert.luau
+         ./slua-analyze tests/conformance/assert.luau
+         ./slua-compile tests/conformance/assert.luau
 
   windows:
     runs-on: windows-2022
@@ -122,9 +122,9 @@ jobs:
         shell: bash # necessary for fail-fast
         run: |
           cmake --build . --target Luau.Repl.CLI Luau.Analyze.CLI Luau.Compile.CLI --config RelWithDebInfo # match config with tests to improve build time
-          RelWithDebInfo/luau tests/conformance/assert.luau
-          RelWithDebInfo/luau-analyze tests/conformance/assert.luau
-          RelWithDebInfo/luau-compile tests/conformance/assert.luau
+          RelWithDebInfo/slua tests/conformance/assert.luau
+          RelWithDebInfo/slua-analyze tests/conformance/assert.luau
+          RelWithDebInfo/slua-compile tests/conformance/assert.luau
 
   coverage:
     runs-on: ubuntu-22.04

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -22,17 +22,17 @@ jobs:
       run: cmake --build . --target Luau.Repl.CLI Luau.Analyze.CLI Luau.Compile.CLI Luau.Ast.CLI --config Release -j 2
     - name: pack
       if: matrix.os.name != 'windows'
-      run: zip luau-${{github.event.release.tag_name}}-${{matrix.os.name}}.zip luau*
+      run: zip slua-${{github.event.release.tag_name}}-${{matrix.os.name}}.zip slua*
     - name: pack
       if: matrix.os.name == 'windows'
-      run: 7z a luau-${{github.event.release.tag_name}}-${{matrix.os.name}}.zip .\Release\luau*.exe
+      run: 7z a slua-${{github.event.release.tag_name}}-${{matrix.os.name}}.zip .\Release\slua*.exe
     - uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ github.event.release.upload_url }}
-        asset_path: luau-${{github.event.release.tag_name}}-${{matrix.os.name}}.zip
-        asset_name: luau-${{github.event.release.tag_name}}-${{matrix.os.name}}.zip
+        asset_path: slua-${{github.event.release.tag_name}}-${{matrix.os.name}}.zip
+        asset_name: slua-${{github.event.release.tag_name}}-${{matrix.os.name}}.zip
         asset_content_type: application/octet-stream
 
   package:
@@ -131,5 +131,5 @@ jobs:
       with:
         upload_url: ${{ github.event.release.upload_url }}
         asset_path: Luau.Web.js
-        asset_name: Luau.Web.js
+        asset_name: SLua.Web.js
         asset_content_type: application/octet-stream

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,11 @@
 /luau-analyze
 /luau-bytecode
 /luau-compile
+/slua
+/slua-tests
+/slua-analyze
+/slua-bytecode
+/slua-compile
 __pycache__
 /stage
 .cache

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,12 +64,12 @@ if(LUAU_BUILD_CLI)
     add_executable(Luau.Bytecode.CLI)
 
     # This also adds target `name` on Linux/macOS and `name.exe` on Windows
-    set_target_properties(Luau.Repl.CLI PROPERTIES OUTPUT_NAME luau)
-    set_target_properties(Luau.Analyze.CLI PROPERTIES OUTPUT_NAME luau-analyze)
-    set_target_properties(Luau.Ast.CLI PROPERTIES OUTPUT_NAME luau-ast)
-    set_target_properties(Luau.Reduce.CLI PROPERTIES OUTPUT_NAME luau-reduce)
-    set_target_properties(Luau.Compile.CLI PROPERTIES OUTPUT_NAME luau-compile)
-    set_target_properties(Luau.Bytecode.CLI PROPERTIES OUTPUT_NAME luau-bytecode)
+    set_target_properties(Luau.Repl.CLI PROPERTIES OUTPUT_NAME slua)
+    set_target_properties(Luau.Analyze.CLI PROPERTIES OUTPUT_NAME slua-analyze)
+    set_target_properties(Luau.Ast.CLI PROPERTIES OUTPUT_NAME slua-ast)
+    set_target_properties(Luau.Reduce.CLI PROPERTIES OUTPUT_NAME slua-reduce)
+    set_target_properties(Luau.Compile.CLI PROPERTIES OUTPUT_NAME slua-compile)
+    set_target_properties(Luau.Bytecode.CLI PROPERTIES OUTPUT_NAME slua-bytecode)
 endif()
 
 if(LUAU_BUILD_TESTS)

--- a/Makefile
+++ b/Makefile
@@ -54,23 +54,23 @@ ISOCLINE_TARGET=$(BUILD)/libisocline.a
 
 TESTS_SOURCES=$(wildcard tests/*.cpp) CLI/src/FileUtils.cpp CLI/src/Flags.cpp CLI/src/Profiler.cpp CLI/src/Coverage.cpp CLI/src/Repl.cpp CLI/src/ReplRequirer.cpp CLI/src/VfsNavigator.cpp CLI/src/LSLBuiltins.cpp
 TESTS_OBJECTS=$(TESTS_SOURCES:%=$(BUILD)/%.o)
-TESTS_TARGET=$(BUILD)/luau-tests
+TESTS_TARGET=$(BUILD)/slua-tests
 
 REPL_CLI_SOURCES=CLI/src/FileUtils.cpp CLI/src/Flags.cpp CLI/src/Profiler.cpp CLI/src/Coverage.cpp CLI/src/Repl.cpp CLI/src/ReplEntry.cpp CLI/src/ReplRequirer.cpp CLI/src/VfsNavigator.cpp CLI/src/LSLBuiltins.cpp
 REPL_CLI_OBJECTS=$(REPL_CLI_SOURCES:%=$(BUILD)/%.o)
-REPL_CLI_TARGET=$(BUILD)/luau
+REPL_CLI_TARGET=$(BUILD)/slua
 
 ANALYZE_CLI_SOURCES=CLI/src/FileUtils.cpp CLI/src/Flags.cpp CLI/src/Analyze.cpp CLI/src/AnalyzeRequirer.cpp CLI/src/VfsNavigator.cpp
 ANALYZE_CLI_OBJECTS=$(ANALYZE_CLI_SOURCES:%=$(BUILD)/%.o)
-ANALYZE_CLI_TARGET=$(BUILD)/luau-analyze
+ANALYZE_CLI_TARGET=$(BUILD)/slua-analyze
 
 COMPILE_CLI_SOURCES=CLI/src/FileUtils.cpp CLI/src/Flags.cpp CLI/src/Compile.cpp CLI/src/LSLBuiltins.cpp
 COMPILE_CLI_OBJECTS=$(COMPILE_CLI_SOURCES:%=$(BUILD)/%.o)
-COMPILE_CLI_TARGET=$(BUILD)/luau-compile
+COMPILE_CLI_TARGET=$(BUILD)/slua-compile
 
 BYTECODE_CLI_SOURCES=CLI/src/FileUtils.cpp CLI/src/Flags.cpp CLI/src/Bytecode.cpp
 BYTECODE_CLI_OBJECTS=$(BYTECODE_CLI_SOURCES:%=$(BUILD)/%.o)
-BYTECODE_CLI_TARGET=$(BUILD)/luau-bytecode
+BYTECODE_CLI_TARGET=$(BUILD)/slua-bytecode
 
 FUZZ_SOURCES=$(wildcard fuzz/*.cpp) fuzz/luau.pb.cpp
 FUZZ_OBJECTS=$(FUZZ_SOURCES:%=$(BUILD)/%.o)
@@ -84,7 +84,7 @@ ifneq ($(opt),)
 endif
 
 OBJECTS=$(COMMON_OBJECTS) $(AST_OBJECTS) $(COMPILER_OBJECTS) $(CONFIG_OBJECTS) $(ANALYSIS_OBJECTS) $(EQSAT_OBJECTS) $(CODEGEN_OBJECTS) $(VM_OBJECTS) $(CJSON_OBJECTS) $(APR_OBJECTS) $(REQUIRE_OBJECTS) $(ISOCLINE_OBJECTS) $(TESTS_OBJECTS) $(REPL_CLI_OBJECTS) $(ANALYZE_CLI_OBJECTS) $(COMPILE_CLI_OBJECTS) $(BYTECODE_CLI_OBJECTS) $(FUZZ_OBJECTS)
-EXECUTABLE_ALIASES = luau luau-analyze luau-compile luau-bytecode luau-tests
+EXECUTABLE_ALIASES = slua slua-analyze slua-compile slua-bytecode slua-tests
 
 # common flags
 # We have to do tailslide builds for `make`-based builds, conditionally including the LSL compiler is annoying in `make`.
@@ -212,9 +212,9 @@ coverage: $(TESTS_TARGET) $(COMPILE_CLI_TARGET)
 	mv default.profraw codegen-x64.profraw
 	llvm-profdata merge *.profraw -o default.profdata
 	rm *.profraw
-	llvm-cov show -format=html -show-instantiations=false -show-line-counts=true -show-region-summary=false -ignore-filename-regex=\(tests\|extern\|CLI\)/.* -output-dir=coverage --instr-profile default.profdata -object build/coverage/luau-tests -object build/coverage/luau-compile
-	llvm-cov report -ignore-filename-regex=\(tests\|extern\|CLI\|stage\)/.* -show-region-summary=false --instr-profile default.profdata -object build/coverage/luau-tests -object build/coverage/luau-compile
-	llvm-cov export -ignore-filename-regex=\(tests\|extern\|CLI\|stage\)/.* -format lcov --instr-profile default.profdata -object build/coverage/luau-tests -object build/coverage/luau-compile >coverage.info
+	llvm-cov show -format=html -show-instantiations=false -show-line-counts=true -show-region-summary=false -ignore-filename-regex=\(tests\|extern\|CLI\)/.* -output-dir=coverage --instr-profile default.profdata -object build/coverage/slua-tests -object build/coverage/slua-compile
+	llvm-cov report -ignore-filename-regex=\(tests\|extern\|CLI\|stage\)/.* -show-region-summary=false --instr-profile default.profdata -object build/coverage/slua-tests -object build/coverage/slua-compile
+	llvm-cov export -ignore-filename-regex=\(tests\|extern\|CLI\|stage\)/.* -format lcov --instr-profile default.profdata -object build/coverage/slua-tests -object build/coverage/slua-compile >coverage.info
 
 format:
 	git ls-files '*.h' '*.cpp' | xargs clang-format-11 -i
@@ -228,19 +228,19 @@ check-source:
 	git ls-files '*.h' ':!:extern' | xargs -I+ sh -c 'grep -L "#pragma once" +'
 
 # executable target aliases
-luau: $(REPL_CLI_TARGET)
+slua: $(REPL_CLI_TARGET)
 	ln -fs $^ $@
 
-luau-analyze: $(ANALYZE_CLI_TARGET)
+slua-analyze: $(ANALYZE_CLI_TARGET)
 	ln -fs $^ $@
 
-luau-compile: $(COMPILE_CLI_TARGET)
+slua-compile: $(COMPILE_CLI_TARGET)
 	ln -fs $^ $@
 
-luau-bytecode: $(BYTECODE_CLI_TARGET)
+slua-bytecode: $(BYTECODE_CLI_TARGET)
 	ln -fs $^ $@
 
-luau-tests: $(TESTS_TARGET)
+slua-tests: $(TESTS_TARGET)
 	ln -fs $^ $@
 
 # executable targets

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ cmake --build . --target Luau.Analyze.CLI --config RelWithDebInfo
 Alternatively, on Linux and macOS, you can also use `make`:
 
 ```sh
-make config=release luau luau-analyze
+make config=release slua slua-analyze
 ```
 
 To integrate SLua into your CMake application projects as a library, at the minimum, you'll need to depend on `Luau.Compiler` and `Luau.VM` projects. From there you need to create a new Luau state (using Lua 5.x API such as `lua_newstate`), compile source to bytecode and load it into the VM like this:

--- a/build-cmd.sh
+++ b/build-cmd.sh
@@ -80,7 +80,7 @@ pushd "$top"
             cp -v "Release/Luau.VM.lib" "$stage/lib/release/"
             cp -v "Release/Luau.Common.lib" "$stage/lib/release/"
 
-            cp -v Release/luau.exe "$stage/bin/"
+            cp -v Release/slua.exe "$stage/bin/"
         ;;
         darwin*|linux*)
             # Continue compiling with asserts for now
@@ -101,7 +101,7 @@ pushd "$top"
             cp -v "libLuau.Config.a" "$stage/lib/release"
             cp -v "libLuau.VM.a" "$stage/lib/release"
 
-            cp -v "luau" "$stage/bin/"
+            cp -v "slua" "$stage/bin/"
 
             # Run the conformance test for good measure
             "${stage}/build/Luau.Conformance"


### PR DESCRIPTION
Rename output binaries to slua instead of luau, will make more sense going forward especially as people start using `slua-analyze` as it will have differences to `luau-analyze`.

Also allow users that may have both setup for various reasons to more easily use them.

### Please Note

**Due to how the make file reuses the targets for the file names the make commands have also changed to `make slua` etc, I guess don't merge if that is undesirable**